### PR TITLE
Better handle errors when using callbacks

### DIFF
--- a/meteor-file.js
+++ b/meteor-file.js
@@ -152,15 +152,27 @@ if (Meteor.isClient) {
     upload: function (file, method, options, callback) {
       var self = this;
 
-      if (!Blob.prototype.isPrototypeOf(file))
-        throw new Meteor.Error("First parameter must inherit from Blob");
-
-      if (!_.isString(method))
-        throw new Meteor.Error("Second parameter must be a Meteor.method name");
-
       if (arguments.length < 4 && _.isFunction(options)) {
         callback = options;
         options = {};
+      }
+
+      var error = null;
+      if (!Blob.prototype.isPrototypeOf(file)) {
+        error = new Meteor.Error(400, "First parameter must inherit from Blob");
+      }
+
+      if (!_.isString(method)) {
+        error = new Meteor.Error(400, "Second parameter must be a Meteor.method name");
+      }
+
+      if (error) {
+        if (callback) {
+          return callback(error);
+        }
+        else {
+          throw error;
+        }
       }
 
       options = options || {};


### PR DESCRIPTION
`Meteor.Error` should get a numeric value for the first argument. And if callback is provided you should not be throwing an exception, user does not get any feedback (upload just gets stuck) and Meteor logs a strange error into the console, hard to understand why it failed.
